### PR TITLE
Update waxctl binary endpoints with Scarf

### DIFF
--- a/waxctl.rb
+++ b/waxctl.rb
@@ -8,7 +8,7 @@ class Waxctl < Formula
   version "0.6.3"
 
   on_macos do
-    url "https://github.com/bytewax/waxctl-downloads/releases/download/v0.6.3/waxctl_0.6.3_darwin_all.tar.gz"
+    url "https://bytewax.gateway.scarf.sh/waxctl/0.6.3/darwin/all"
     sha256 "92f9de822a52836df90eabf8b0c1ba40f0d7a95dfd6de2c42145310063e86459"
 
     def install
@@ -18,7 +18,7 @@ class Waxctl < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/bytewax/waxctl-downloads/releases/download/v0.6.3/waxctl_0.6.3_linux_arm64.tar.gz"
+      url "https://bytewax.gateway.scarf.sh/waxctl/0.6.3/linux/arm64"
       sha256 "a2b699800b2316617361e6736eb40171868e99a6c8c0435befab68a7419c4daf"
 
       def install
@@ -26,7 +26,7 @@ class Waxctl < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/bytewax/waxctl-downloads/releases/download/v0.6.3/waxctl_0.6.3_linux_amd64.tar.gz"
+      url "https://bytewax.gateway.scarf.sh/waxctl/0.6.3/linux/amd64"
       sha256 "76afca54399f649fa319bad37c2f2c79af3d1a0a26e79c47e4e482556c6e35a0"
 
       def install


### PR DESCRIPTION
Updated waxctl brew binary URLs to run through Scarf endpoint. Scarf is a tool that allows maintainers to track open-source project adoption and usage metrics. Updating the binary endpoints to redirect through Scarf first lets these metrics be collected for product improvement